### PR TITLE
Refactor examples to use shared utils for port selection

### DIFF
--- a/examples/chat/chat.py
+++ b/examples/chat/chat.py
@@ -1,11 +1,12 @@
 import argparse
-import random
-import socket
 import sys
 
 import multiaddr
 import trio
 
+from examples.utils import (
+    get_random_available_port,
+)
 from libp2p import (
     new_host,
 )
@@ -103,23 +104,6 @@ def main() -> None:
         trio.run(run, *(port, args.destination))
     except KeyboardInterrupt:
         pass
-
-
-def is_port_available(port: int) -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        try:
-            sock.bind(("", port))
-            return True
-        except OSError:
-            return False
-
-
-def get_random_available_port(start: int = 10000, end: int = 20000) -> int:
-    for _ in range(50):  # try up to 50 random ports
-        port = random.randint(start, end)
-        if is_port_available(port):
-            return port
-    raise RuntimeError("Could not find an available port in the given range.")
 
 
 if __name__ == "__main__":

--- a/examples/echo/echo.py
+++ b/examples/echo/echo.py
@@ -1,10 +1,11 @@
 import argparse
-import random
-import socket
 
 import multiaddr
 import trio
 
+from examples.utils import (
+    get_random_available_port,
+)
 from libp2p import (
     new_host,
 )
@@ -75,6 +76,7 @@ async def run(port: int, destination: str, seed: int = None) -> None:
             msg = b"hi, there!\n"
 
             await stream.write(msg)
+            # TODO: check why the stream is closed after the first write ???
             # Notify the other side about EOF
             await stream.close()
             response = await stream.read()
@@ -116,23 +118,6 @@ def main() -> None:
         trio.run(run, port, args.destination, args.seed)
     except KeyboardInterrupt:
         pass
-
-
-def is_port_available(port: int) -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        try:
-            sock.bind(("", port))
-            return True
-        except OSError:
-            return False
-
-
-def get_random_available_port(start: int = 10000, end: int = 20000) -> int:
-    for _ in range(50):  # try up to 50 random ports
-        port = random.randint(start, end)
-        if is_port_available(port):
-            return port
-    raise RuntimeError("Could not find an available port in the given range.")
 
 
 if __name__ == "__main__":

--- a/examples/identify/identify.py
+++ b/examples/identify/identify.py
@@ -5,6 +5,7 @@ import logging
 import multiaddr
 import trio
 
+from examples.utils import get_random_available_port  # <-- Add this import
 from libp2p import (
     new_host,
 )
@@ -104,13 +105,11 @@ def main() -> None:
     """
 
     example_maddr = (
-        "/ip4/127.0.0.1/tcp/8888/p2p/QmQn4SwGkDZkUEpBRBvTmheQycxAHJUNmVEnjA2v1qe8Q"
+        "/ip4/127.0.0.1/tcp/8888/p2p/QmQn4SwGkDZKkUEpBRBvTmheQycxAHJUNmVEnjA2v1qe8Q"
     )
 
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        "-p", "--port", default=8888, type=int, help="source port number"
-    )
+    parser.add_argument("-p", "--port", type=int, help="source port number (optional)")
     parser.add_argument(
         "-d",
         "--destination",
@@ -119,11 +118,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if not args.port:
-        raise RuntimeError("failed to determine local port")
+    # Use random port if not specified
+    port = args.port if args.port is not None else get_random_available_port()
 
     try:
-        trio.run(run, *(args.port, args.destination))
+        trio.run(run, *(port, args.destination))
     except KeyboardInterrupt:
         pass
 

--- a/examples/identify_push/identify_push_listener_dialer.py
+++ b/examples/identify_push/identify_push_listener_dialer.py
@@ -28,6 +28,7 @@ from multiaddr import (
 )
 import trio
 
+from examples.utils import get_random_available_port  # Add this import
 from libp2p import (
     new_host,
 )
@@ -57,7 +58,7 @@ from libp2p.peer.peerinfo import (
 logger = logging.getLogger("libp2p.identity.identify-push-example")
 
 # Default port configuration
-DEFAULT_PORT = 8888
+EXAMPLE_DEFAULT_PORT = 8888
 
 
 def custom_identify_push_handler_for(host):
@@ -246,8 +247,8 @@ def main() -> None:
     """
 
     example = (
-        f"/ip4/127.0.0.1/tcp/{DEFAULT_PORT}/p2p/"
-        "QmQn4SwGkDZkUEpBRBvTmheQycxAHJUNmVEnjA2v1qe8Q"
+        f"/ip4/127.0.0.1/tcp/{EXAMPLE_DEFAULT_PORT}/p2p/"
+        "QmQn4SwGkDZKkUEpBRBvTmheQycxAHJUNmVEnjA2v1qe8Q"
     )
 
     parser = argparse.ArgumentParser(description=description)
@@ -256,8 +257,8 @@ def main() -> None:
         "--port",
         type=int,
         help=(
-            f"port to listen on (default: {DEFAULT_PORT} for listener, "
-            f"{DEFAULT_PORT + 1} for dialer)"
+            f"port to listen on (default: {EXAMPLE_DEFAULT_PORT} for listener, "
+            f"{EXAMPLE_DEFAULT_PORT + 1} for dialer)"
         ),
     )
     parser.add_argument(
@@ -270,12 +271,12 @@ def main() -> None:
 
     try:
         if args.destination:
-            # Run in dialer mode with default port DEFAULT_PORT + 1 if not specified
-            port = args.port if args.port is not None else DEFAULT_PORT + 1
+            # Run in dialer mode with random available port if not specified
+            port = args.port if args.port is not None else get_random_available_port()
             trio.run(run_dialer, port, args.destination)
         else:
-            # Run in listener mode with default port DEFAULT_PORT if not specified
-            port = args.port if args.port is not None else DEFAULT_PORT
+            # Run in listener mode with random available port if not specified
+            port = args.port if args.port is not None else get_random_available_port()
             trio.run(run_listener, port)
     except KeyboardInterrupt:
         print("\nInterrupted by user")

--- a/examples/ping/ping.py
+++ b/examples/ping/ping.py
@@ -1,10 +1,11 @@
 import argparse
-import random
-import socket
 
 import multiaddr
 import trio
 
+from examples.utils import (
+    get_random_available_port,
+)
 from libp2p import (
     new_host,
 )
@@ -98,7 +99,6 @@ def main() -> None:
     )
 
     parser = argparse.ArgumentParser(description=description)
-
     parser.add_argument("-p", "--port", type=int, help="source port number (optional)")
     parser.add_argument(
         "-d",
@@ -113,23 +113,6 @@ def main() -> None:
         trio.run(run, *(port, args.destination))
     except KeyboardInterrupt:
         pass
-
-
-def is_port_available(port: int) -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        try:
-            sock.bind(("", port))
-            return True
-        except OSError:
-            return False
-
-
-def get_random_available_port(start: int = 10000, end: int = 20000) -> int:
-    for _ in range(50):  # try up to 50 random ports
-        port = random.randint(start, end)
-        if is_port_available(port):
-            return port
-    raise RuntimeError("Could not find an available port in the given range.")
 
 
 if __name__ == "__main__":

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,0 +1,21 @@
+import random
+import socket
+
+
+def is_port_available(port: int) -> bool:
+    """Check if a TCP port is available on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind(("", port))
+            return True
+        except OSError:
+            return False
+
+
+def get_random_available_port(start: int = 10000, end: int = 20000) -> int:
+    """Find a random available TCP port in the given range."""
+    for _ in range(50):  # try up to 50 random ports
+        port = random.randint(start, end)
+        if is_port_available(port):
+            return port
+    raise RuntimeError("Could not find an available port in the given range.")


### PR DESCRIPTION
# Examples Utils

This module provides utility functions for the example scripts in the `examples/` directory.

## Functions

- **is_port_available(port: int) -> bool**  
  Checks if a TCP port is available on localhost.

- **get_random_available_port(start: int = 10000, end: int = 20000) -> int**  
  Returns a random available TCP port within the specified range.

## Usage

Import the functions in your example scripts:

```python
from examples.utils import is_port_available, get_random_available_port
```

Use `get_random_available_port()` to automatically select a free port for your libp2p host, and `is_port_available()` to check port availability.
